### PR TITLE
Instancing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,8 @@ examples:
 	$(EXAMPLE_CMD) examples/ip.ml -o ip.out &&\
 	$(EXAMPLE_CMD) examples/text.ml -o text.out &&\
 	$(EXAMPLE_CMD) examples/noise.ml -o noise.out &&\
-	$(EXAMPLE_CMD) examples/shoot.ml -o shoot.out
+	$(EXAMPLE_CMD) examples/shoot.ml -o shoot.out &&\
+	$(EXAMPLE_CMD) examples/instancing.ml -o instancing.out
 
 tests: math_lib core_lib graphics_lib utils_lib
 	$(TEST_CMD) tests/programs.ml -o main.out && $(LAUNCH_CMD) &&\

--- a/TODO
+++ b/TODO
@@ -55,6 +55,8 @@ New modules:
     ☐ Octree
 
 Advanced features:
+  ☐ Vertex buffer slices
+  ☐ Index buffer slices
   More Image and Texture types:
     ☐ Single-channeled images
     ☐ Image slices

--- a/TODO
+++ b/TODO
@@ -43,6 +43,7 @@ Interface changes:
   RenderTextures/Framebuffers:
     ☐ Test all attachments
   ☐ Unify exceptions
+  ☐ More tests! (especially for vertex arrays)
 
 New modules:
   Bounding module:

--- a/TODO
+++ b/TODO
@@ -42,6 +42,7 @@ Interface changes:
     ☐ (+Shape) Centralize transformations
   RenderTextures/Framebuffers:
     ☐ Test all attachments
+  ☐ Unify exceptions
 
 New modules:
   Bounding module:

--- a/examples/cube.ml
+++ b/examples/cube.ml
@@ -11,12 +11,16 @@ let fps_clock =
   Clock.create ()
 
 let cube_source =
-  let src = VertexArray.VertexSource.empty ~size:36 () in
+  let src = VertexArray.Source.empty ~size:36 () in
   let cmod = Model.cube Vector3f.({x = -0.5; y = -0.5; z = -0.5}) Vector3f.({x = 1.; y = 1.; z = 1.}) in
   Model.source cmod ~vertex_source:src ();
   src
 
-let cube = VertexArray.static (module Window) window cube_source
+let cube_vbo = 
+  VertexArray.Buffer.static (module Window) window cube_source
+
+let cube = 
+  VertexArray.create (module Window) window [VertexArray.Buffer.unpack cube_vbo]
 
 let normal_program =
   Program.from_source_pp (module Window) ~context:window

--- a/examples/instancing.ml
+++ b/examples/instancing.ml
@@ -1,0 +1,237 @@
+open OgamlGraphics
+open OgamlMath
+open OgamlUtils
+
+let settings = OgamlCore.ContextSettings.create ~msaa:8 ()
+
+let window =
+  Window.create ~width:800 ~height:600 ~title:"Cube Instancing Example" ~settings ()
+
+let fps_clock = 
+  Clock.create ()
+
+(* Create the VBO for one cube *)
+let cube_source =
+  let src = VertexArray.Source.empty ~size:36 () in
+  let cmod = Model.cube Vector3f.({x = -0.5; y = -0.5; z = -0.5}) Vector3f.({x = 1.; y = 1.; z = 1.}) in
+  Model.source cmod ~vertex_source:src ();
+  src
+
+let cube_vbo = 
+  VertexArray.Buffer.static (module Window) window cube_source
+
+(* Create instanced data for the position of each cube *)
+module InstancedData = (val VertexArray.Vertex.make ())
+
+let cube_position =
+  let open VertexArray.Vertex in
+  InstancedData.attribute "cube_position" ~divisor:1 AttributeType.vector3f
+
+let () = InstancedData.seal ()
+
+(* Create the instanced VBO *)
+let () = Random.self_init ()
+
+let random_position () = 
+  let v = Vector3f.({x = Random.float 400. -. 200.; 
+                     y = Random.float 400. -. 200.; 
+                     z = Random.float 400. -. 200.})
+  in
+  let vtx = InstancedData.create () in
+  VertexArray.Vertex.Attribute.set vtx cube_position v;
+  vtx
+  
+let instanced_source =
+  let src = VertexArray.Source.empty ~size:36 () in
+  for i = 0 to 10000 do
+    VertexArray.Source.add src (random_position ())
+  done;
+  src
+
+let instanced_vbo = 
+  VertexArray.Buffer.static (module Window) window instanced_source
+
+(* Create the VAO that contains both VBOs *)
+let cube = 
+  VertexArray.create (module Window) window 
+    [VertexArray.Buffer.unpack cube_vbo;
+     VertexArray.Buffer.unpack instanced_vbo]
+
+
+let vertex_shader = "
+  uniform mat4 MMatrix;
+
+  uniform mat4 VPMatrix;
+
+  in vec3 cube_position;
+
+  in vec3 position;
+  
+  in vec3 normal;
+  
+  in vec4 color;
+  
+  out vec3 out_normal;
+  
+  out vec4 out_color;
+  
+  
+  void main() {
+  
+    gl_Position = VPMatrix * (MMatrix * vec4(position, 1.0) + vec4(cube_position, 1.0));
+  
+    out_normal = normal;
+  
+    out_color = color;
+  
+  }
+"
+
+let normal_program =
+  Program.from_source_pp (module Window) ~context:window
+    ~vertex_source:(`String vertex_shader)
+    ~fragment_source:(`File (OgamlCore.OS.resources_dir ^ "examples/normals_shader.frag")) ()
+
+(* Display computations *)
+let proj = Matrix3D.perspective ~near:0.01 ~far:1000. ~width:800. ~height:600. ~fov:(90. *. 3.141592 /. 180.)
+
+let position = ref Vector3f.({x = 1.; y = 0.6; z = 1.4})
+
+let rot_angle = ref 0.
+
+let view_theta = ref 0.
+
+let view_phi = ref 0.
+
+let msaa = ref true
+
+let display () =
+  (* Compute model matrix *)
+  let t = Unix.gettimeofday () in
+  let view = Matrix3D.look_at_eulerian ~from:!position ~theta:!view_theta ~phi:!view_phi in
+  let rot_vector = Vector3f.({x = (cos t); y = (sin t); z = (cos t) *. (sin t)}) in
+  let model = Matrix3D.rotation rot_vector !rot_angle in
+  let vp = Matrix3D.product proj view in
+  let mv = Matrix3D.product view model in
+  let mvp = Matrix3D.product vp model in
+  rot_angle := !rot_angle +. (abs_float (cos t /. 10.)) /. 3.;
+  let parameters =
+    DrawParameter.(make
+      ~culling:CullingMode.CullClockwise
+      ~antialiasing:!msaa ())
+  in
+  let uniform =
+    Uniform.empty
+    |> Uniform.matrix3D "MVPMatrix" mvp
+    |> Uniform.matrix3D "MMatrix"   model
+    |> Uniform.matrix3D "VPMatrix"  vp
+    |> Uniform.matrix3D "MVMatrix" mv
+    |> Uniform.matrix3D "VMatrix" view
+    |> Uniform.vector3f "Light.LightDir" Vector3f.{x = -4.; y = -2.; z = -3.}
+    |> Uniform.vector3f "Light.AmbientIntensity" Vector3f.{x = 0.3; y = 0.3; z = 0.3}
+    |> Uniform.float    "Light.SunIntensity" 1.6
+    |> Uniform.float    "Light.MaxIntensity" 1.9
+    |> Uniform.float    "Light.Gamma"  1.2
+  in
+  VertexArray.draw (module Window) ~target:window
+                   ~vertices:cube ~uniform ~program:normal_program ~parameters ~mode:DrawMode.Triangles ()
+
+
+(* Camera *)
+let center = Vector2i.div 2 (Window.size window)
+
+let () =
+  Mouse.set_relative_position window center
+
+let rec update_camera () =
+  let vmouse = Mouse.relative_position window in
+  let dv = Vector2i.sub vmouse center in
+  let lim = Constants.pi /. 2. -. 0.1 in
+  view_theta := !view_theta -. 0.005 *. (float_of_int dv.OgamlMath.Vector2i.x);
+  view_phi   := !view_phi   -. 0.005 *. (float_of_int dv.OgamlMath.Vector2i.y);
+  view_phi   := min (max !view_phi (-.lim)) lim;
+  Mouse.set_relative_position window center
+
+(* Handle keys directly by polling the keyboard *)
+let handle_keys () =
+  OgamlCore.Keycode.(Keyboard.(
+    if is_pressed Z || is_pressed Up then
+      position := Vector3f.(add
+        !position
+        {x = -. 0.15 *. (sin !view_theta);
+         y = 0.;
+         z = -. 0.15 *. (cos !view_theta)}) ;
+    if is_pressed S || is_pressed Down then
+      position := Vector3f.(add
+        !position
+        {x = 0.15 *. (sin !view_theta);
+         y = 0.;
+         z = 0.15 *. (cos !view_theta)}) ;
+    if is_pressed Q || is_pressed Left then
+      position := Vector3f.(add
+        !position
+        {x = -. 0.15 *. (cos !view_theta);
+         y = 0.;
+         z = 0.15 *. (sin !view_theta)}) ;
+    if is_pressed D || is_pressed Right then
+      position := Vector3f.(add
+        !position
+        {x = 0.15 *. (cos !view_theta);
+         y = 0.;
+         z = -. 0.15 *. (sin !view_theta)});
+    if is_pressed LShift then
+      position := Vector3f.(add
+        !position
+        {x = 0.; y = -0.15; z = 0.});
+    if is_pressed Space then
+      position := Vector3f.(add
+        !position
+        {x = 0.; y = 0.15; z = 0.})
+  ))
+
+
+(* Event loop *)
+let rec event_loop () =
+  let open OgamlCore in
+  match Window.poll_event window with
+  |Some e -> begin
+    match e with
+    |Event.Closed ->
+      Window.close window
+    |Event.KeyPressed k -> Keycode.(
+      match k.Event.KeyEvent.key with
+      | Escape -> Window.close window
+      | Q when k.Event.KeyEvent.control -> Window.close window
+      | A -> msaa := (not !msaa)
+      | P -> Image.save (Window.screenshot window) "screenshot.png"
+      | _ -> ()
+    )
+    | _ -> ()
+  end; event_loop ()
+  |None -> ()
+
+
+(* Main loop *)
+let rec main_loop () =
+  if Window.is_open window then begin
+    Window.clear ~color:(Some (`RGB Color.RGB.white)) window;
+    display ();
+    Window.display window;
+    (* We only capture the mouse and listen to the keyboard when focused *)
+    if Window.has_focus window then (
+      update_camera () ;
+      handle_keys ()
+    ) ;
+    event_loop ();
+    Clock.tick fps_clock;
+    main_loop ()
+  end
+
+
+(* Start *)
+let () =
+  Printf.printf "Rendering %i vertices\n%!" (VertexArray.length cube);
+  Clock.restart fps_clock;
+  main_loop ();
+  Printf.printf "Avg FPS: %f\n%!" (Clock.tps fps_clock);
+  Window.destroy window

--- a/examples/tut02.ml
+++ b/examples/tut02.ml
@@ -67,18 +67,26 @@ let vertex3 =
     ~position:Vector3f.({x = 0.75; y = -0.75; z = 0.0}) ()
 
 (* Put the vertices in a vertex source *)
-let vertex_source = VertexArray.VertexSource.(
+let vertex_source = VertexArray.Source.(
     empty ~size:3 ()
     << vertex1
     << vertex2
     << vertex3
 )
 
-(* Compute and load the VAO (Vertex Array Object)
- * VAOs need a valid GL context to be properly initialized, which
+(* Compute and load the VBO (Vertex Buffer Object)
+ * VBOs need a valid GL context to be properly initialized, which
  * is encapsulated inside any render target (window, render texture, ...).
  * Hence the use of first-class modules to provide some polymorphism. *)
-let vertices = VertexArray.static (module Window) window vertex_source
+let vbo = VertexArray.Buffer.static (module Window) window vertex_source
+
+(* Compute the VAO (Vertex Array Object)
+ * A VAO encapsulates a collection of VBOs. Since VBOs can have different
+ * types depending on the data they contain, we first need to unpack the
+ * VBO to be able to construct a heterogeneous list of VBOs. *)
+let unpacked_vbo = VertexArray.Buffer.unpack vbo 
+
+let vertices = VertexArray.create (module Window) window [unpacked_vbo]
 
 (* Event-listening loop *)
 let rec event_loop () =

--- a/examples/tut_idx.ml
+++ b/examples/tut_idx.ml
@@ -74,7 +74,7 @@ let vertex7 =
   VertexArray.SimpleVertex.create
     ~position:(Vector3f.({x =  0.5; y =  0.5; z = 0.5})) ()
 
-let vertex_source = VertexArray.VertexSource.(
+let vertex_source = VertexArray.Source.(
     empty ~size:8 ()
     << vertex0 << vertex1 << vertex2
     << vertex3 << vertex4 << vertex5
@@ -91,7 +91,9 @@ let index_source = IndexArray.Source.(
     << 4 << 6 << 2 << 4 << 2 << 0
 )
 
-let vertices = VertexArray.static (module Window) window vertex_source
+let vbo = VertexArray.Buffer.static (module Window) window vertex_source
+
+let vertices = VertexArray.(create (module Window) window [Buffer.unpack vbo])
 
 let indices  = IndexArray.static (module Window) window index_source
 

--- a/examples/tut_tex.ml
+++ b/examples/tut_tex.ml
@@ -64,7 +64,7 @@ let vertex4 =
     ~position:Vector3f.({x = 0.75; y = -0.75; z = 0.0})
     ~uv:Vector2f.({x = 1.; y = 0.}) ()
 
-let vertex_source = VertexArray.VertexSource.(
+let vertex_source = VertexArray.Source.(
     empty ~size:4 ()
     << vertex1
     << vertex2
@@ -72,7 +72,10 @@ let vertex_source = VertexArray.VertexSource.(
     << vertex4
 )
 
-let vertices = VertexArray.static (module Window) window vertex_source
+let vbo = VertexArray.Buffer.static (module Window) window vertex_source
+
+let vertices = 
+  VertexArray.(create (module Window) window [Buffer.unpack vbo])
 
 let texture = Texture.Texture2D.create (module Window) window (`File "examples/mario-block.bmp")
 

--- a/examples/vertexmaps.ml
+++ b/examples/vertexmaps.ml
@@ -68,7 +68,7 @@ let make_vertex nm pos (r,g,b) =
   v
 
 let cube_source =
-  VertexArray.VertexSource.(
+  VertexArray.Source.(
     empty ()
     << make_vertex Vector3i.unit_x Vector3f.({x =  0.5; y =  0.5; z =  0.5}) (255, 0, 0)
     << make_vertex Vector3i.unit_x Vector3f.({x =  0.5; y = -0.5; z =  0.5}) (255, 0, 0)
@@ -107,7 +107,9 @@ let cube_indices =
     << 20 << 21 << 23 << 21 << 22 << 23
   )
 
-let cube = VertexArray.static (module Window) window cube_source
+let cube_vbo = VertexArray.Buffer.static (module Window) window cube_source
+
+let cube = VertexArray.(create (module Window) window [Buffer.unpack cube_vbo])
 
 let indices = IndexArray.static (module Window) window cube_indices
 

--- a/src/graphics/2d/shape.ml
+++ b/src/graphics/2d/shape.ml
@@ -343,16 +343,17 @@ let draw (type s) (module M : RenderTarget.T with type t = s)
     |> Uniform.vector2f "size" (Vector2f.from_int size)
   in
   let vertices = 
-    let src = VertexArray.VertexSource.empty
+    let src = VertexArray.Source.empty
       ~size:8 ()
     in
     let vtcs, outline = compute_vertices shape in
-    List.iter (VertexArray.VertexSource.add src) vtcs;
+    List.iter (VertexArray.Source.add src) vtcs;
     begin match outline with
     | None -> ()
-    | Some vtcs -> List.iter (VertexArray.VertexSource.add src) vtcs
+    | Some vtcs -> List.iter (VertexArray.Source.add src) vtcs
     end;
-    VertexArray.static (module M) target src
+    let vbo = VertexArray.Buffer.(unpack (static (module M) target src)) in
+    VertexArray.create (module M) target [vbo]
   in
   VertexArray.draw (module M)
         ~target
@@ -364,17 +365,17 @@ let draw (type s) (module M : RenderTarget.T with type t = s)
 
 let map_to_source shape f src = 
   let vtcs, outline = compute_vertices shape in
-  List.iter (fun v -> VertexArray.VertexSource.add src (f v)) vtcs;
+  List.iter (fun v -> VertexArray.Source.add src (f v)) vtcs;
   begin match outline with
   | None -> ()
-  | Some vtcs -> List.iter (fun v -> VertexArray.VertexSource.add src (f v)) vtcs
+  | Some vtcs -> List.iter (fun v -> VertexArray.Source.add src (f v)) vtcs
   end
 
 let to_source shape src = 
   let vtcs, outline = compute_vertices shape in
-  List.iter (VertexArray.VertexSource.add src) vtcs;
+  List.iter (VertexArray.Source.add src) vtcs;
   begin match outline with
   | None -> ()
-  | Some vtcs -> List.iter (VertexArray.VertexSource.add src) vtcs
+  | Some vtcs -> List.iter (VertexArray.Source.add src) vtcs
   end
 

--- a/src/graphics/2d/shape.mli
+++ b/src/graphics/2d/shape.mli
@@ -62,11 +62,11 @@ val draw :
     (module RenderTarget.T with type t = 'a) ->
     ?parameters:DrawParameter.t -> target:'a -> shape:t -> unit -> unit
 
-val to_source : t -> VertexArray.SimpleVertex.T.s VertexArray.VertexSource.t -> unit
+val to_source : t -> VertexArray.SimpleVertex.T.s VertexArray.Source.t -> unit
 
 val map_to_source : t -> 
                     (VertexArray.SimpleVertex.T.s VertexArray.Vertex.t -> 'b VertexArray.Vertex.t) -> 
-                    'b VertexArray.VertexSource.t -> unit
+                    'b VertexArray.Source.t -> unit
 
 
 (** Sets the position of the origin in the window. *)

--- a/src/graphics/2d/sprite.ml
+++ b/src/graphics/2d/sprite.ml
@@ -116,13 +116,13 @@ let create ~texture
   }
 
 let map_to_source sprite f src = 
-  List.iter (fun v -> VertexArray.VertexSource.add src (f v)) (get_vertices sprite)
+  List.iter (fun v -> VertexArray.Source.add src (f v)) (get_vertices sprite)
 
 let to_source sprite src = 
-  List.iter (VertexArray.VertexSource.add src) (get_vertices sprite)
+  List.iter (VertexArray.Source.add src) (get_vertices sprite)
 
 let map_to_custom_source sprite f src = 
-  List.iter (fun v -> VertexArray.VertexSource.add src (f v)) (get_vertices sprite)
+  List.iter (fun v -> VertexArray.Source.add src (f v)) (get_vertices sprite)
 
 let draw (type s) (module Target : RenderTarget.T with type t = s)
          ?parameters:(parameters = DrawParameter.make
@@ -139,10 +139,13 @@ let draw (type s) (module Target : RenderTarget.T with type t = s)
     |> Uniform.texture2D "utexture" sprite.texture
   in
   let vertices = 
-    let sprite_source = VertexArray.VertexSource.empty ~size:6 () in
-    List.iter (VertexArray.VertexSource.add sprite_source) (get_vertices sprite);
-    let vao = VertexArray.static (module Target) target sprite_source in
-    vao
+    let sprite_source = VertexArray.Source.empty ~size:6 () in
+    List.iter (VertexArray.Source.add sprite_source) (get_vertices sprite);
+    let vao = 
+      VertexArray.Buffer.static (module Target) target sprite_source 
+      |> VertexArray.Buffer.unpack
+    in
+    VertexArray.create (module Target) target [vao]
   in
   VertexArray.draw (module Target)
         ~target

--- a/src/graphics/2d/sprite.mli
+++ b/src/graphics/2d/sprite.mli
@@ -22,14 +22,14 @@ val draw :
   (module RenderTarget.T with type t = 'a) ->
   ?parameters:DrawParameter.t -> target:'a -> sprite:t -> unit -> unit
 
-val to_source : t -> VertexArray.SimpleVertex.T.s VertexArray.VertexSource.t -> unit
+val to_source : t -> VertexArray.SimpleVertex.T.s VertexArray.Source.t -> unit
 
 (** Outputs a sprite to a vertex array source by mapping its vertices.
   *
   * See $to_source$ for more information. *)
 val map_to_source : t -> 
                     (VertexArray.SimpleVertex.T.s VertexArray.Vertex.t -> 'b VertexArray.Vertex.t) -> 
-                    'b VertexArray.VertexSource.t -> unit
+                    'b VertexArray.Source.t -> unit
 
 (** Sets the position of the origin of the sprite in the window. *)
 val set_position : t -> OgamlMath.Vector2f.t -> unit

--- a/src/graphics/2d/text.ml
+++ b/src/graphics/2d/text.ml
@@ -8,7 +8,7 @@ module Fx = struct
     font       : Font.t;
     size       : int;
     chars      : ((float * Font.code * Font.Glyph.t) * Color.t) list ;
-    vertices   : (VertexArray.static, VertexArray.SimpleVertex.T.s) VertexArray.t ;
+    vertices   : VertexArray.t ;
     advance    : Vector2f.t ;
     boundaries : FloatRect.t
   }
@@ -169,7 +169,7 @@ module Fx = struct
                ~color
                ()
            in
-           VertexArray.VertexSource.(
+           VertexArray.Source.(
              source << v1 << v2 << v3
                     << v3 << v1 << v4
            ),
@@ -179,16 +179,18 @@ module Fx = struct
            line_width
         )
         (
-          VertexArray.VertexSource.empty 
+          VertexArray.Source.empty 
               ~size:((UTF8String.length utf8) * 6)
               (),
           Vector2f.zero,
           0.
         )
         chars
-      |> fun (source, advance, line_width) -> VertexArray.static (module M) target source,
-                                         advance,
-                                         max advance.Vector2f.x line_width
+      |> fun (source, advance, line_width) -> 
+          let vbo = VertexArray.Buffer.static (module M) target source in 
+          (VertexArray.create (module M) target [VertexArray.Buffer.unpack vbo],
+          advance,
+          max advance.Vector2f.x line_width)
     in
     let boundaries = {
       FloatRect.x      = position.Vector2f.x ;
@@ -389,11 +391,12 @@ let draw (type s) (module M : RenderTarget.T with type t = s)
   in
   let vertices = 
     let vtx = text.vertices in
-    let src = VertexArray.VertexSource.empty
+    let src = VertexArray.Source.empty
       ~size:32 () 
     in
-    List.iter (VertexArray.VertexSource.add src) vtx;
-    VertexArray.static (module M) target src
+    List.iter (VertexArray.Source.add src) vtx;
+    let vbo = VertexArray.Buffer.(unpack (static (module M) target src)) in
+    VertexArray.create (module M) target [vbo]
   in
   VertexArray.draw
         (module M)
@@ -405,10 +408,10 @@ let draw (type s) (module M : RenderTarget.T with type t = s)
         ~mode:DrawMode.Triangles ()
 
 let to_source text src = 
-  List.iter (VertexArray.VertexSource.add src) text.vertices
+  List.iter (VertexArray.Source.add src) text.vertices
 
 let map_to_source text f src = 
-  List.iter (fun v -> VertexArray.VertexSource.add src (f v)) text.vertices
+  List.iter (fun v -> VertexArray.Source.add src (f v)) text.vertices
 
 let advance text = text.advance
 

--- a/src/graphics/2d/text.mli
+++ b/src/graphics/2d/text.mli
@@ -58,11 +58,11 @@ val draw :
   target : 'a ->
   unit -> unit
 
-val to_source : t -> VertexArray.SimpleVertex.T.s VertexArray.VertexSource.t -> unit
+val to_source : t -> VertexArray.SimpleVertex.T.s VertexArray.Source.t -> unit
 
 val map_to_source : t -> 
                     (VertexArray.SimpleVertex.T.s VertexArray.Vertex.t -> 'b VertexArray.Vertex.t) -> 
-                    'b VertexArray.VertexSource.t -> unit
+                    'b VertexArray.Source.t -> unit
 
 val advance : t -> OgamlMath.Vector2f.t
 

--- a/src/graphics/backend/GL.ml
+++ b/src/graphics/backend/GL.ml
@@ -389,9 +389,16 @@ module VAO = struct
   external attrib_int : 
     int -> int -> GLTypes.GlIntType.t -> int -> int -> unit = "caml_attrib_int"
 
+  external attrib_divisor : 
+    int -> int -> unit = "caml_attrib_divisor"
+
   external draw : DrawMode.t -> int -> int -> unit = "caml_draw_arrays"
 
+  external draw_instanced : DrawMode.t -> int -> int -> int -> unit = "caml_draw_arrays_instanced"
+
   external draw_elements : DrawMode.t -> int -> int -> unit = "caml_draw_elements"
+
+  external draw_elements_instanced : DrawMode.t -> int -> int -> int -> unit = "caml_draw_elements_instanced"
 
 end
 

--- a/src/graphics/backend/GL.mli
+++ b/src/graphics/backend/GL.mli
@@ -384,11 +384,20 @@ module VAO : sig
   (** Binds an integer attribute to an offset and a type in a VBO *)
   val attrib_int : Program.a_location -> int -> GLTypes.GlIntType.t -> int -> int -> unit
 
+  (** Modifies the rate at which a vertex attribute advance during instanced rendering *) 
+  val attrib_divisor : Program.a_location -> int -> unit
+
   (** Draws the currently bound VAO *)
   val draw : DrawMode.t -> int -> int -> unit
 
+  (** Draws the currently bound VAO w/ instancing *)
+  val draw_instanced : DrawMode.t -> int -> int -> int -> unit
+
   (** Draws an element array using the currently bound VAO and EBO *)
   val draw_elements : DrawMode.t -> int -> int -> unit
+
+  (** Draws an element array using the currently bound VAO and EBO w/ instancing *)
+  val draw_elements_instanced : DrawMode.t -> int -> int -> int -> unit
 
 end
 

--- a/src/graphics/backend/context.mli
+++ b/src/graphics/backend/context.mli
@@ -27,6 +27,18 @@ type capabilities = {
   max_color_attachments     : int;
 }
 
+(** Pool of free IDs (used for textures, buffers, etc)
+  * Finalizers should call free on the ID *)
+module ID_Pool : sig
+
+  type t
+
+  val get_next : t -> int
+
+  val free : t -> int -> unit
+
+end
+
 (** Type of the GL context *)
 type t
 
@@ -114,8 +126,8 @@ module LL : sig
   (** Returns the currently active texture unit *)
   val texture_unit : t -> int
 
-  (** Returns a new fresh texture id *)
-  val texture_id : t -> int
+  (** Returns the texture ID pool *)
+  val texture_pool : t -> ID_Pool.t
 
   (** Sets the currently bound texture ID to a texture unit and a target *)
   val set_bound_texture : t -> int -> (GL.Texture.t * int * GLTypes.TextureTarget.t) option -> unit
@@ -135,8 +147,8 @@ module LL : sig
   (** Returns the currently linked program ID *)
   val linked_program : t -> int option
 
-  (** Returns a new fresh program ID *)
-  val program_id : t -> int
+  (** Returns the program ID pool *)
+  val program_pool : t -> ID_Pool.t
 
   (** Sets the currently bound VBO *)
   val set_bound_vbo : t -> (GL.VBO.t * int) option -> unit
@@ -144,14 +156,17 @@ module LL : sig
   (** Returns the currently bound VBO ID *)
   val bound_vbo : t -> int option
 
+  (** Returns the vbo ID pool *)
+  val vbo_pool : t -> ID_Pool.t
+
   (** Sets the currently bound VAO *)
   val set_bound_vao : t -> (GL.VAO.t * int) option -> unit
 
   (** Returns the currently bound VAO ID *)
   val bound_vao : t -> int option
 
-  (** Returns a new fresh vao ID *)
-  val vao_id : t -> int
+  (** Returns the vao ID pool *)
+  val vao_pool : t -> ID_Pool.t
 
   (** Sets the current clear color *)
   val set_clear_color : t -> Color.t -> unit
@@ -162,8 +177,8 @@ module LL : sig
   (** Returns the currently bound EBO ID *)
   val bound_ebo : t -> int option
 
-  (** Returns a new fresh ebo ID *)
-  val ebo_id : t -> int
+  (** Returns the ebo ID pool *)
+  val ebo_pool : t -> ID_Pool.t
 
   (** Returns the currently bound FBO ID *)
   val bound_fbo : t -> int
@@ -171,11 +186,11 @@ module LL : sig
   (** Sets the currently bound FBO *)
   val set_bound_fbo : t -> (GL.FBO.t * int) option -> unit
 
-  (** Returns a new fresh fbo ID *)
-  val fbo_id : t -> int
+  (** Returns the fbo ID pool *)
+  val fbo_pool : t -> ID_Pool.t
 
-  (** Returns a new fresh rbo ID *)
-  val rbo_id : t -> int
+  (** Returns the rbo ID pool *)
+  val rbo_pool : t -> ID_Pool.t
 
   (** Returns whether alpha blending is currently enabled *)
   val blending : t -> bool

--- a/src/graphics/backend/context.mli
+++ b/src/graphics/backend/context.mli
@@ -159,13 +159,13 @@ module LL : sig
   (** Returns the vbo ID pool *)
   val vbo_pool : t -> ID_Pool.t
 
-  (** Sets the currently bound VAO *)
+  (** Sets the currently bound VBO *)
   val set_bound_vao : t -> (GL.VAO.t * int) option -> unit
 
-  (** Returns the currently bound VAO ID *)
+  (** Returns the currently bound VBO ID *)
   val bound_vao : t -> int option
 
-  (** Returns the vao ID pool *)
+  (** Returns the vbo ID pool *)
   val vao_pool : t -> ID_Pool.t
 
   (** Sets the current clear color *)

--- a/src/graphics/fbo/framebuffer.ml
+++ b/src/graphics/fbo/framebuffer.ml
@@ -18,14 +18,26 @@ type t = {
 let create (type a) (module T : RenderTarget.T with type t = a) (target : a) =
   let context = T.context target in
   let fbo = GL.FBO.create () in
+  let idpool = Context.LL.fbo_pool context in
+  let id = Context.ID_Pool.get_next idpool in
   let maxattc = (Context.capabilities context).Context.max_color_attachments in
   let color_attachments = Array.make maxattc None in
-  {fbo; context; id = Context.LL.fbo_id context;
-   color = false; depth = false; stencil = false;
-   color_attachments; 
-   depth_attachment = None;
-   stencil_attachment = None; 
-   depth_stencil_attachment = None}
+  let fbo_ = {
+    fbo; 
+    context; 
+    id;
+    color = false; depth = false; stencil = false;
+    color_attachments; 
+    depth_attachment = None;
+    stencil_attachment = None; 
+    depth_stencil_attachment = None}
+  in
+  Gc.finalise (fun _ -> 
+    Context.ID_Pool.free idpool id;
+    if Context.LL.bound_fbo context = id then
+      Context.LL.set_bound_fbo context None
+  ) fbo_;
+  fbo_
 
 let attach_color (type a) (module A : Attachment.ColorAttachable with type t = a)
                  fbo nb (attachment : a) =

--- a/src/graphics/fbo/renderbuffer.ml
+++ b/src/graphics/fbo/renderbuffer.ml
@@ -14,7 +14,8 @@ module ColorBuffer = struct
   let create (type a) (module M : RenderTarget.T with type t = a) target size = 
     let internal = GL.RBO.create () in
     let context = M.context target in
-    let id = Context.LL.rbo_id context in
+    let idpool = Context.LL.rbo_pool context in
+    let id = Context.ID_Pool.get_next idpool in
     let capabilities = Context.capabilities context in
     if size.Vector2i.x >= capabilities.Context.max_renderbuffer_size 
     || size.Vector2i.y >= capabilities.Context.max_renderbuffer_size then
@@ -22,7 +23,9 @@ module ColorBuffer = struct
     GL.RBO.bind (Some internal);
     GL.RBO.storage GLTypes.TextureFormat.RGBA8 size.Vector2i.x size.Vector2i.y;
     GL.RBO.bind None;
-    {id; internal; size}
+    let buf = {id; internal; size} in
+    Gc.finalise (fun _ -> Context.ID_Pool.free idpool id) buf;
+    buf
 
   let to_color_attachment t = 
     Attachment.ColorAttachment.ColorRBO t.internal
@@ -43,7 +46,8 @@ module DepthBuffer = struct
   let create (type a) (module M : RenderTarget.T with type t = a) target size = 
     let internal = GL.RBO.create () in
     let context = M.context target in
-    let id = Context.LL.rbo_id context in
+    let idpool = Context.LL.rbo_pool context in
+    let id = Context.ID_Pool.get_next idpool in
     let capabilities = Context.capabilities context in
     if size.Vector2i.x >= capabilities.Context.max_renderbuffer_size 
     || size.Vector2i.y >= capabilities.Context.max_renderbuffer_size then
@@ -51,7 +55,9 @@ module DepthBuffer = struct
     GL.RBO.bind (Some internal);
     GL.RBO.storage GLTypes.TextureFormat.Depth24 size.Vector2i.x size.Vector2i.y;
     GL.RBO.bind None;
-    {id; internal; size}
+    let buf = {id; internal; size} in
+    Gc.finalise (fun _ -> Context.ID_Pool.free idpool id) buf;
+    buf
 
   let to_depth_attachment t = 
     Attachment.DepthAttachment.DepthRBO t.internal
@@ -72,7 +78,8 @@ module DepthStencilBuffer = struct
   let create (type a) (module M : RenderTarget.T with type t = a) target size = 
     let internal = GL.RBO.create () in
     let context = M.context target in
-    let id = Context.LL.rbo_id context in
+    let idpool = Context.LL.rbo_pool context in
+    let id = Context.ID_Pool.get_next idpool in
     let capabilities = Context.capabilities context in
     if size.Vector2i.x >= capabilities.Context.max_renderbuffer_size
     || size.Vector2i.y >= capabilities.Context.max_renderbuffer_size then
@@ -80,7 +87,9 @@ module DepthStencilBuffer = struct
     GL.RBO.bind (Some internal);
     GL.RBO.storage GLTypes.TextureFormat.Depth24Stencil8 size.Vector2i.x size.Vector2i.y;
     GL.RBO.bind None;
-    {id; internal; size}
+    let buf = {id; internal; size} in
+    Gc.finalise (fun _ -> Context.ID_Pool.free idpool id) buf;
+    buf
 
   let to_depth_stencil_attachment t = 
     Attachment.DepthStencilAttachment.DepthStencilRBO t.internal
@@ -101,7 +110,8 @@ module StencilBuffer = struct
   let create (type a) (module M : RenderTarget.T with type t = a) target size = 
     let internal = GL.RBO.create () in
     let context = M.context target in
-    let id = Context.LL.rbo_id context in
+    let idpool = Context.LL.rbo_pool context in
+    let id = Context.ID_Pool.get_next idpool in
     let capabilities = Context.capabilities context in
     if size.Vector2i.x >= capabilities.Context.max_renderbuffer_size 
     || size.Vector2i.y >= capabilities.Context.max_renderbuffer_size then
@@ -109,7 +119,9 @@ module StencilBuffer = struct
     GL.RBO.bind (Some internal);
     GL.RBO.storage GLTypes.TextureFormat.Stencil8 size.Vector2i.x size.Vector2i.y;
     GL.RBO.bind None;
-    {id; internal; size}
+    let buf = {id; internal; size} in
+    Gc.finalise (fun _ -> Context.ID_Pool.free idpool id) buf;
+    buf
 
   let to_stencil_attachment t = 
     Attachment.StencilAttachment.StencilRBO t.internal

--- a/src/graphics/model/model.ml
+++ b/src/graphics/model/model.ml
@@ -184,14 +184,14 @@ let simplify t =
 let source (t : t) ?index_source ~vertex_source () =
   let source_vertex v = 
     let va = Vertex.to_vao v in
-    try VertexArray.VertexSource.add vertex_source va
-    with VertexArray.VertexSource.Uninitialized_field s -> raise (Error s)
+    try VertexArray.Source.add vertex_source va
+    with VertexArray.Source.Uninitialized_field s -> raise (Error s)
   in
   let indices = Hashtbl.create 97 in
   let get_index v = 
     try Hashtbl.find indices v 
     with Not_found -> 
-      let ind = VertexArray.VertexSource.length vertex_source in
+      let ind = VertexArray.Source.length vertex_source in
       source_vertex v;
       Hashtbl.add indices v ind;
       ind

--- a/src/graphics/model/model.mli
+++ b/src/graphics/model/model.mli
@@ -75,7 +75,7 @@ val compute_normals : ?smooth:bool -> t -> t
 val simplify : t -> t
 
 val source : t -> ?index_source:IndexArray.Source.t 
-               -> vertex_source:VertexArray.SimpleVertex.T.s VertexArray.VertexSource.t 
+               -> vertex_source:VertexArray.SimpleVertex.T.s VertexArray.Source.t 
                -> unit -> unit
 
 

--- a/src/graphics/ogamlGraphics.mli
+++ b/src/graphics/ogamlGraphics.mli
@@ -1842,8 +1842,15 @@ module VertexArray : sig
   (** Returns the length of a vertex array *)
   val length : ('a, 'b) t -> int
 
-  (** Draws the slice starting at $start$ of length $length$ of a vertex array on a
-    * window using the given parameters.
+  (** $slice vao start length$ returns the slice of $vao$ of length $length$
+    * starting at $start$.
+    *
+    * Raises $Out_of_bounds$ if the slice is invalid *)
+  val slice  : ('a, 'b) t -> int -> int -> ('a, 'b) t 
+
+  (** Draws $length$ vertices starting from $start$ of the vertex array $vertices$
+    * on $target$ using the given parameters. Note: $start$ and $length$ are cumulative
+    * with vertex array slices.
     *
     * $start$ defaults to 0
     *

--- a/src/graphics/ogamlGraphics.mli
+++ b/src/graphics/ogamlGraphics.mli
@@ -1518,12 +1518,12 @@ module IndexArray : sig
     * @see:OgamlGraphics.IndexArray.Source *)
   val dynamic : (module RenderTarget.T with type t = 'a) -> 'a -> Source.t -> dynamic t
 
-  (** $rebuild array src offset$ rebuilds $array$ starting from
+  (** $rebuild (module M) context array src offset$ rebuilds $array$ starting from
     * the index at position $offset$ using $src$.
     *
     * The index array is modified in-place and is resized as needed.
     * @see:OgamlGraphics.IndexArray.Source *)
-  val rebuild : dynamic t -> Source.t -> int -> unit
+  val rebuild : (module RenderTarget.T with type t = 'a) -> 'a -> dynamic t -> Source.t -> int -> unit
 
   (** Returns the length of an index array *)
   val length : 'a t -> int
@@ -1642,6 +1642,9 @@ module VertexArray : sig
         * Raises $Unbound_attribute$ if the attribute is not initialized. *)
       val get : 'b t -> ('a, 'b) s -> 'a
 
+      (** Returns the divisor of the attribute used during instanced rendering. *)
+      val divisor : ('a, 'b) s -> int
+
       (** Returns the name of an attribute, that is, the name
         * that will refer to this attribute in a GLSL program. *)
       val name : ('a, 'b) s -> string
@@ -1659,8 +1662,12 @@ module VertexArray : sig
       type s
 
       (** Adds an attribute to this structure.
+        *
+        * $divisor$ corresponds to the attribute's divisor for instanced rendering,
+        * and defaults to $0$ (non-instanced) 
+        *
         * Raises $Sealed_vertex$ if the structure is sealed. *)
-      val attribute : string -> 'a AttributeType.s -> ('a, s) Attribute.s
+      val attribute : string -> ?divisor:int -> 'a AttributeType.s -> ('a, s) Attribute.s
 
       (** Seals this structure. Once sealed, the structure can be used to
         * create vertices but cannot receive new attributes.
@@ -1825,12 +1832,12 @@ module VertexArray : sig
   val dynamic : (module RenderTarget.T with type t = 'a) 
                  -> 'a -> 'b VertexSource.t -> (dynamic, 'b) t
 
-  (** $rebuild array src offset$ rebuilds $array$ starting from
+  (** $rebuild (module M) context array src offset$ rebuilds $array$ starting from
     * the vertex at position $offset$ using $src$.
     *
     * The vertex array is modified in-place and is resized as needed.
     * @see:OgamlGraphics.VertexArray.Source *)
-  val rebuild : (dynamic, 'b) t -> 'b VertexSource.t -> int -> unit
+  val rebuild : (module RenderTarget.T with type t = 'a) -> 'a -> (dynamic, 'b) t -> 'b VertexSource.t -> int -> unit
 
   (** Returns the length of a vertex array *)
   val length : ('a, 'b) t -> int

--- a/src/graphics/stubs/vao_stubs.c
+++ b/src/graphics/stubs/vao_stubs.c
@@ -146,6 +146,22 @@ caml_attrib_int(value loc, value size, value type, value off, value stride)
 }
 
 
+// INPUT   an attribute location, an int
+// OUTPUT  nothing, sets the attribute's divisor
+CAMLprim value
+caml_attrib_divisor(value loc, value divisor)
+{
+  CAMLparam2(loc, divisor);
+
+  GLuint glloc = (GLuint)Int_val(loc);
+  GLint  gldiv = Int_val(divisor);
+
+  glVertexAttribDivisor(glloc, gldiv);
+
+  CAMLreturn(Val_unit);
+}
+
+
 // INPUT   a draw mode, two indices (start, end)
 // OUTPUT  nothing, draws the currently bound VAO
 CAMLprim value
@@ -159,15 +175,42 @@ caml_draw_arrays(value mode, value start, value end)
 }
 
 
+// INPUT   a draw mode, two indices (start, end)
+// OUTPUT  nothing, draws the currently bound VAO
+CAMLprim value
+caml_draw_arrays_instanced(value mode, value start, value end, value count)
+{
+  CAMLparam4(mode, start, end, count);
+
+  glDrawArraysInstanced(Drawmode_val(mode), Int_val(start), Int_val(end), Int_val(count));
+
+  CAMLreturn(Val_unit);
+}
+
+
 // INPUT   a draw mode, a number of elements
 // OUTPUT  nothing, draws the requested number of elements from
 //         the currently bound EBO and VAO
 CAMLprim value
 caml_draw_elements(value mode, value first, value nb)
 {
-  CAMLparam2(mode, nb);
+  CAMLparam3(mode, first, nb);
 
   glDrawElements(Drawmode_val(mode), Int_val(nb), GL_UNSIGNED_INT, (GLvoid*)Int_val(first));
+
+  CAMLreturn(Val_unit);
+}
+
+
+// INPUT   a draw mode, a number of elements
+// OUTPUT  nothing, draws the requested number of elements from
+//         the currently bound EBO and VAO
+CAMLprim value
+caml_draw_elements_instanced(value mode, value first, value nb, value count)
+{
+  CAMLparam4(mode, first, nb, count);
+
+  glDrawElementsInstanced(Drawmode_val(mode), Int_val(nb), GL_UNSIGNED_INT, (GLvoid*)Int_val(first), Int_val(count));
 
   CAMLreturn(Val_unit);
 }

--- a/src/graphics/texture/texture.ml
+++ b/src/graphics/texture/texture.ml
@@ -78,14 +78,23 @@ module Common = struct
   let create context mipmaps target =
     (* Create the texture *)
     let internal = GL.Texture.create () in
+    let idpool = Context.LL.texture_pool context in
+    let id = Context.ID_Pool.get_next idpool in
     let tex = {internal; 
-               context = context;
+               context;
                target;
                mipmaps;
-               id = Context.LL.texture_id context; 
+               id;
                wrap = Some GLTypes.WrapFunction.ClampEdge;
                magnify = Some GLTypes.MagnifyFilter.Linear;
                minify = Some GLTypes.MinifyFilter.LinearMipmapLinear} in
+    Gc.finalise (fun _ -> 
+      Context.ID_Pool.free idpool id;
+      for i = 0 to (Context.capabilities context).Context.max_texture_image_units - 1 do
+        if Context.LL.bound_texture context i = Some id then
+          Context.LL.set_bound_texture context i None
+      done
+    ) tex;
     (* Bind it *)
     bind tex 0;
     (* Set reasonable parameters *)

--- a/src/graphics/vertex/indexArray.ml
+++ b/src/graphics/vertex/indexArray.ml
@@ -44,30 +44,51 @@ type _ t = {
 let dynamic (type s) (module M : RenderTarget.T with type t = s) target src = 
   let buffer = GL.EBO.create () in
   let data = src.Source.data in
+  let context = M.context target in
+  let idpool = Context.LL.ebo_pool context in
+  let id = Context.ID_Pool.get_next idpool in
   GL.EBO.bind (Some buffer);
   GL.EBO.data (GL.Data.length data * 4) (Some data) (GLTypes.VBOKind.DynamicDraw);
   GL.EBO.bind None;
-  {
-    buffer;
-    size = GL.Data.length data;
-    length = Source.length src; 
-    id = Context.LL.ebo_id (M.context target)
-  }
+  Context.LL.set_bound_ebo context None;
+  let ebo = {
+      buffer;
+      size = GL.Data.length data;
+      length = Source.length src; 
+      id}
+  in
+  Gc.finalise (fun _ ->
+    Context.ID_Pool.free idpool id;
+    if Context.LL.bound_ebo context = Some id then
+      Context.LL.set_bound_ebo context None
+  ) ebo;
+  ebo
 
 let static (type s) (module M : RenderTarget.T with type t = s) target src = 
   let buffer = GL.EBO.create () in
   let data = src.Source.data in
+  let context = M.context target in
+  let idpool = Context.LL.ebo_pool context in
+  let id = Context.ID_Pool.get_next idpool in
   GL.EBO.bind (Some buffer);
   GL.EBO.data (GL.Data.length data * 4) (Some data) (GLTypes.VBOKind.StaticDraw);
   GL.EBO.bind None;
-  {
-    buffer;
-    size = GL.Data.length data;
-    length = Source.length src; 
-    id = Context.LL.ebo_id (M.context target)
-  }
+  Context.LL.set_bound_ebo context None;
+  let ebo = {
+      buffer;
+      size = GL.Data.length data;
+      length = Source.length src; 
+      id}
+  in
+  Gc.finalise (fun _ ->
+    Context.ID_Pool.free idpool id;
+    if Context.LL.bound_ebo context = Some id then
+      Context.LL.set_bound_ebo context None
+  ) ebo;
+  ebo
 
-let rebuild t src start =
+
+let rebuild (type s) (module M : RenderTarget.T with type t = s) target t src start =
   let data = src.Source.data in
   let new_buffer = 
     if t.size < GL.Data.length data + start then begin
@@ -83,6 +104,7 @@ let rebuild t src start =
   GL.EBO.bind (Some new_buffer);
   GL.EBO.subdata (start * 4) (GL.Data.length data * 4) data;
   GL.EBO.bind None;
+  Context.LL.set_bound_ebo (M.context target) None;
   t.buffer <- new_buffer;
   t.length <- Source.length src + start;
   t.size   <- max (GL.Data.length data + start) t.size

--- a/src/graphics/vertex/indexArray.mli
+++ b/src/graphics/vertex/indexArray.mli
@@ -25,7 +25,7 @@ val static : (module RenderTarget.T with type t = 'a) -> 'a -> Source.t -> stati
 
 val dynamic : (module RenderTarget.T with type t = 'a) -> 'a -> Source.t -> dynamic t
 
-val rebuild : dynamic t -> Source.t -> int -> unit
+val rebuild : (module RenderTarget.T with type t = 'a) -> 'a -> dynamic t -> Source.t -> int -> unit
 
 val length : 'a t -> int
 

--- a/src/graphics/vertex/vertexArray.ml
+++ b/src/graphics/vertex/vertexArray.ml
@@ -284,7 +284,7 @@ module SimpleVertex = struct
 end
 
 
-module VertexSource = struct
+module Source = struct
 
   exception Uninitialized_field of string
 
@@ -312,16 +312,8 @@ module VertexSource = struct
       init_size = size;
       fdata = GL.Data.create_float 0;
       idata = GL.Data.create_int 0;
-      layout = None
+      layout = None;
     }
-
-  let time_1 = ref 0.
-
-  let iterations_1 = ref 0
-
-  let time_2 = ref 0.
-
-  let iterations_2 = ref 0
 
   let add src vtx = 
     if src.layout = None then begin
@@ -520,68 +512,239 @@ module VertexSource = struct
 end
 
 
+module Buffer = struct
+
+  exception Invalid_attribute of string
+
+  exception Out_of_bounds of string
+
+  type static
+
+  type dynamic
+
+  type 'b unsafe = {
+    mutable buffer  : GL.VBO.t;
+    (* Length of the floating-point data *)
+    mutable size_f  : int;
+    (* Length of the integer data *)
+    mutable size_i  : int;
+    (* Number of vertices *)
+    mutable length  : int;
+    init_fields : ('b Vertex.boxed_attrib * int) list;
+    (* Stride for integer data *)
+    stride_i  : int;
+    (* Stride for floating-point data *)
+    stride_f  : int;
+    (* Lowest non-zero instance divisor *)
+    l_divisor : int;
+    (* Is there uninstanced data ? *)
+    uninstanced : bool;
+    id : int
+  }
+
+  type ('a, 'b) t = 'b unsafe
+
+  let create context src kind = 
+    let buffer = GL.VBO.create () in
+    let dataf = src.Source.fdata in
+    let datai = src.Source.idata in
+    let length = Source.length src in
+    let lengthf = GL.Data.length dataf in
+    let lengthi = GL.Data.length datai in
+    GL.VBO.bind (Some buffer);
+    if lengthi = 0 then
+      GL.VBO.data (lengthf * 4) (Some dataf) kind
+    else begin
+      GL.VBO.data ((lengthf + lengthi) * 4) None kind;
+      GL.VBO.subdata 0 (lengthf * 4) dataf;
+      GL.VBO.subdata (lengthf * 4) (lengthi * 4) datai;
+    end;
+    GL.VBO.bind None;
+    Context.LL.set_bound_vbo context None;
+    let idpool = Context.LL.vbo_pool context in
+    let id = Context.ID_Pool.get_next idpool in
+    let l_divisor = 
+      List.fold_left (fun d (a,_) -> 
+        let div = Vertex.divisor_of a in
+        if div <> 0 then begin
+          if d = 0 then div
+          else min d div
+        end else d
+      ) 0 src.Source.init_fields
+    in
+    let uninstanced = 
+      List.exists (fun (a,_) -> Vertex.divisor_of a = 0) src.Source.init_fields
+    in
+    let vbo_ = {
+      buffer;
+      size_f   = lengthf;
+      size_i   = lengthi;
+      length;
+      init_fields = src.Source.init_fields;
+      stride_i = src.Source.stridei;
+      stride_f = src.Source.stridef;
+      l_divisor;
+      uninstanced;
+      id}
+    in
+    Gc.finalise (fun _ ->
+      Context.ID_Pool.free idpool id;
+      if Context.LL.bound_vbo context = Some id then 
+        Context.LL.set_bound_vbo context None
+    ) vbo_;
+    vbo_
+
+  let dynamic (type s) (module M : RenderTarget.T with type t = s) target src = 
+    create (M.context target) src GLTypes.VBOKind.DynamicDraw
+
+  let static (type s) (module M : RenderTarget.T with type t = s) target src = 
+    create (M.context target) src GLTypes.VBOKind.StaticDraw
+
+  let unpack t = t
+
+  let length t = 
+    t.length
+
+  let blit (type s) (module M : RenderTarget.T with type t = s) target t ?(first=0) ?length src =
+    if first < 0 then
+      raise (Out_of_bounds "Invalid first vertex");
+    let length = 
+      match length with
+      | None -> src.Source.length
+      | Some i -> i
+    in
+    if length < 0 || length > src.Source.length then
+      raise (Out_of_bounds "Invalid blit length");
+    let dataf = src.Source.fdata in
+    let datai = src.Source.idata in
+    let lengthf = src.Source.stridef * length in
+    let lengthi = src.Source.stridei * length in
+    let start_f = t.stride_f * first in
+    let start_i = t.stride_i * first in
+    if t.init_fields <> src.Source.init_fields then
+      raise Source.Incompatible_sources;
+    let new_buffer = 
+      if first + length > t.length then begin
+        let buf = GL.VBO.create () in
+        GL.VBO.bind (Some buf);
+        GL.VBO.data ((lengthf + lengthi + start_f + start_i) * 4) None 
+                    (GLTypes.VBOKind.DynamicDraw);
+        GL.VBO.bind None;
+        GL.VBO.copy_subdata t.buffer buf 0 0 (start_f * 4); 
+        GL.VBO.copy_subdata t.buffer buf (t.size_f * 4) ((lengthf + start_f) * 4) (start_i * 4); 
+        buf
+      end else 
+        t.buffer
+    in
+    GL.VBO.bind (Some new_buffer);
+    GL.VBO.subdata (start_f * 4) (lengthf * 4) dataf;
+    GL.VBO.subdata ((lengthf + start_f + start_i) * 4) (lengthi * 4) datai;
+    GL.VBO.bind None;
+    Context.LL.set_bound_vbo (M.context target) None;
+    t.buffer <- new_buffer;
+    t.size_f <- max (lengthf + start_f) t.size_f;
+    t.size_i <- max (lengthi + start_i) t.size_i;
+    t.length <- first + length
+
+  let bind_to_attrib context t (prog, program_loc) (attribute, offset) = 
+    if Context.LL.bound_vbo context <> Some t.id then begin
+      GL.VBO.bind (Some t.buffer);
+      Context.LL.set_bound_vbo context (Some (t.buffer, t.id));
+    end;
+    let typ = Vertex.type_of attribute in
+    if typ <> Program.Attribute.kind program_loc then
+      raise (Invalid_attribute
+        (Printf.sprintf "Attribute %s has invalid type"
+          (Program.Attribute.name program_loc)
+        ));
+    GL.VAO.enable_attrib (Program.Attribute.location program_loc);
+    GL.VAO.attrib_divisor (Program.Attribute.location program_loc) 
+                          (Vertex.divisor_of attribute);
+    if Vertex.AttributeType.glsl_is_int typ then begin 
+      let offset = t.stride_i - offset in
+      GL.VAO.attrib_int
+        (Program.Attribute.location program_loc)
+        (Vertex.AttributeType.glsl_size typ)
+        (GLTypes.GlIntType.Int)
+        ((t.size_f + offset) * 4)
+        (t.stride_i * 4)
+    end else begin
+      let offset = t.stride_f - offset in
+      GL.VAO.attrib_float 
+        (Program.Attribute.location program_loc)
+        (Vertex.AttributeType.glsl_size typ)
+        (GLTypes.GlFloatType.Float)
+        (offset * 4)
+        (t.stride_f * 4)
+    end
+
+end
+
 exception Missing_attribute of string
 
-exception Invalid_attribute of string
+exception Multiple_definition of string
 
-exception Out_of_bounds of string
+exception Length_mismatch
 
-type static
-
-type dynamic
-
-type ('a, 'b) t = {
-  vao : GL.VAO.t;
-  mutable buffer  : GL.VBO.t;
-  mutable size_f  : int;
-  mutable size_i  : int;
-  mutable length  : int;
-  init_fields : ('b Vertex.boxed_attrib * int) list;
-  (* Stride for integer data *)
-  stride_i  : int;
-  (* Stride for floating-point data *)
-  stride_f  : int;
-  (* Is the data instanced ? *)
-  instanced : bool;
-  (* Last bound program *)
-  mutable bound : Program.t option;
-  id : int
+type 'a t = {
+  vao        : GL.VAO.t;
+  buffers    : 'a Buffer.unsafe list;
+  attributes : (string, 'a Buffer.unsafe * 'a Vertex.boxed_attrib * int) Hashtbl.t;
+  id         : int;
+  bound      : Program.t option;
+  length     : int;
+  instanced  : bool;
+  (* Number of drawable instances *)
+  i_length   : int;
 }
 
-let create context src kind = 
-  let vao    = GL.VAO.create () in
-  let buffer = GL.VBO.create () in
-  let dataf = src.VertexSource.fdata in
-  let datai = src.VertexSource.idata in
-  let lengthf = GL.Data.length dataf in
-  let lengthi = GL.Data.length datai in
-  GL.VBO.bind (Some buffer);
-  if lengthi = 0 then
-    GL.VBO.data (lengthf * 4) (Some dataf) kind
-  else begin
-    GL.VBO.data ((lengthf + lengthi) * 4) None kind;
-    GL.VBO.subdata 0 (lengthf * 4) dataf;
-    GL.VBO.subdata (lengthf * 4) (lengthi * 4) datai;
-  end;
-  GL.VBO.bind None;
-  Context.LL.set_bound_vbo context None;
-  let idpool = Context.LL.vao_pool context in
-  let id = Context.ID_Pool.get_next idpool in
-  let instanced = 
-    List.exists (fun (a,_) -> Vertex.divisor_of a <> 0) src.VertexSource.init_fields
+let create (type s) (module M : RenderTarget.T with type t = s) 
+           ctx buffers =
+  let context = M.context ctx in 
+  let idpool  = Context.LL.vao_pool context in
+  let id      = Context.ID_Pool.get_next idpool in
+  let vao     = GL.VAO.create () in
+  let attributes = Hashtbl.create 13 in
+  let i_length = 
+    List.fold_left (fun div b -> 
+      if b.Buffer.l_divisor = 0 then div
+      else if div = -1 then b.Buffer.l_divisor * (Buffer.length b)
+      else min div (b.Buffer.l_divisor * (Buffer.length b))
+    ) (-1) buffers 
   in
+  let i_length, instanced = 
+    if i_length = -1 then 0,false
+    else i_length,true
+  in
+  let length = 
+    List.fold_left (fun lgt buf ->
+      if not buf.Buffer.uninstanced then lgt
+      else if lgt <> buf.Buffer.length && lgt <> (-1) then
+        raise Length_mismatch
+      else
+        buf.Buffer.length
+    ) (-1) buffers
+    |> max 0
+  in
+  if length = -1 then
+    raise (Invalid_argument "Buffers contain only instanced data");
+  List.iter (fun b -> 
+    List.iter (fun (att,off) ->
+      let n = Vertex.name_of att in
+      if Hashtbl.mem attributes n then
+        raise (Multiple_definition n);
+      Hashtbl.add attributes n (b,att,off)
+    ) b.Buffer.init_fields;
+  ) buffers;
   let vao_ = {
     vao;
-    buffer;
-    size_f   = lengthf;
-    size_i   = lengthi;
-    length   = VertexSource.length src; 
-    init_fields = src.VertexSource.init_fields;
-    stride_i = src.VertexSource.stridei;
-    stride_f = src.VertexSource.stridef;
-    instanced;
+    buffers;
+    attributes;
+    id;
     bound = None;
-    id}
+    length;
+    i_length;
+    instanced}
   in
   Gc.finalise (fun _ ->
     Context.ID_Pool.free idpool id;
@@ -590,113 +753,40 @@ let create context src kind =
   ) vao_;
   vao_
 
-let dynamic (type s) (module M : RenderTarget.T with type t = s) target src = 
-  create (M.context target) src GLTypes.VBOKind.DynamicDraw
+let length t = 
+  t.length
 
-let static (type s) (module M : RenderTarget.T with type t = s) target src = 
-  create (M.context target) src GLTypes.VBOKind.StaticDraw
+let max_instances t = 
+  t.i_length
 
-let length t = t.length
-
-let rebuild (type s) (module M : RenderTarget.T with type t = s) target t src start =
-  let dataf = src.VertexSource.fdata in
-  let datai = src.VertexSource.idata in
-  let lengthf = GL.Data.length dataf in
-  let lengthi = GL.Data.length datai in
-  let start_f = t.stride_f * start in
-  let start_i = t.stride_i * start in
-  if t.init_fields <> src.VertexSource.init_fields then
-    raise VertexSource.Incompatible_sources;
-  let new_buffer, new_binding = 
-    if t.size_f < lengthf + start_f 
-    || t.size_i < lengthi + start_i 
-    then begin
-      let buf = GL.VBO.create () in
-      GL.VBO.bind (Some buf);
-      GL.VBO.data ((lengthf + lengthi + start_f + start_i) * 4) None 
-                  (GLTypes.VBOKind.DynamicDraw);
-      GL.VBO.bind None;
-      GL.VBO.copy_subdata t.buffer buf 0 0 (start_f * 4); 
-      GL.VBO.copy_subdata t.buffer buf (t.size_f * 4) ((lengthf + start_f) * 4) (start_i * 4); 
-      buf, None
-    end else 
-      t.buffer, t.bound
-  in
-  GL.VBO.bind (Some new_buffer);
-  GL.VBO.subdata (start_f * 4) (lengthf * 4) dataf;
-  GL.VBO.subdata ((lengthf + start_f + start_i) * 4) (lengthi * 4) datai;
-  GL.VBO.bind None;
-  Context.LL.set_bound_vbo (M.context target) None;
-  t.buffer <- new_buffer;
-  t.bound  <- new_binding;
-  t.size_f <- max (lengthf + start_f) t.size_f;
-  t.size_i <- max (lengthi + start_i) t.size_i;
-  t.length <- VertexSource.length src + start
-
-let bind context t prog = 
-  if t.bound <> Some prog then begin
-    t.bound <- Some prog;
-    GL.VAO.bind (Some t.vao);
-    Context.LL.set_bound_vao context (Some (t.vao, t.id));
-    GL.VBO.bind (Some t.buffer);
-    Context.LL.set_bound_vbo context (Some (t.buffer, t.id));
-    let attribs = ref t.init_fields in
-    let rec find_remove s = function
-      | [] -> 
-        raise (Missing_attribute 
-          (Printf.sprintf "Attribute %s not provided in vertex source" s)
-        )
-      | (attrib,off)::t when Vertex.name_of attrib = s -> (attrib,off,t)
-      | h::t -> 
-        let (attrib,off,l) = find_remove s t in 
-        (attrib,off,h::l)
-    in
-    List.iter (fun att ->
-        let (attrib,offset,l) = find_remove (Program.Attribute.name att) !attribs in
-        let typ = Vertex.type_of attrib in
-        if typ <> Program.Attribute.kind att then
-          raise (Invalid_attribute
-            (Printf.sprintf "Attribute %s has invalid type"
-              (Program.Attribute.name att)
-            ));
-        GL.VAO.enable_attrib (Program.Attribute.location att);
-        GL.VAO.attrib_divisor (Program.Attribute.location att) (Vertex.divisor_of attrib);
-        if Vertex.AttributeType.glsl_is_int typ then begin 
-          let offset = t.stride_i - offset in
-          GL.VAO.attrib_int
-            (Program.Attribute.location att)
-            (Vertex.AttributeType.glsl_size typ)
-            (GLTypes.GlIntType.Int)
-            ((t.size_f + offset) * 4)
-            (t.stride_i * 4)
-        end else begin
-          let offset = t.stride_f - offset in
-          GL.VAO.attrib_float 
-            (Program.Attribute.location att)
-            (Vertex.AttributeType.glsl_size typ)
-            (GLTypes.GlFloatType.Float)
-            (offset     * 4)
-            (t.stride_f * 4)
-        end
-      ) (Program.LL.attributes prog);
+let bind context vao program = 
+  if vao.bound <> Some program then begin
+    GL.VAO.bind (Some vao.vao);
+    Context.LL.set_bound_vao context (Some (vao.vao, vao.id));
+    List.iter (fun program_attrib ->
+      let aname = Program.Attribute.name program_attrib in 
+      if not (Hashtbl.mem vao.attributes aname) then
+        raise (Missing_attribute aname);
+      let (vbo, att, offset) = Hashtbl.find vao.attributes aname in
+      Buffer.bind_to_attrib context vbo (program, program_attrib) (att, offset)
+    ) (Program.LL.attributes program)
+  end else if Context.LL.bound_vao context <> Some vao.id then begin
+    GL.VAO.bind (Some vao.vao);
+    Context.LL.set_bound_vao context (Some (vao.vao, vao.id))
   end
-  else if Context.LL.bound_vao context <> (Some t.id) then begin
-    GL.VAO.bind (Some t.vao);
-    Context.LL.set_bound_vao context (Some (t.vao, t.id));
-  end
-
-
+ 
 let draw (type s) (module M : RenderTarget.T with type t = s)
-         ~vertices ~target ?indices ~program
+         ~vertices ~target ?instances ?indices ~program
          ?uniform:(uniform = Uniform.empty) 
          ?parameters:(parameters = DrawParameter.make ()) 
-         ?start ?length
+         ?start
+         ?length
          ?mode:(mode = DrawMode.Triangles) () =
   if vertices.length <> 0 then begin
     let context = M.context target in
     let start = 
       match start with
-      |None -> 0
+      |None   -> 0
       |Some i -> i
     in
     let length = 
@@ -705,27 +795,35 @@ let draw (type s) (module M : RenderTarget.T with type t = s)
       |None, Some ebo -> IndexArray.length ebo - start
       |Some l, _ -> l
     in
+    let instances = 
+      match instances with
+      | None   -> max_instances vertices
+      | Some i -> 
+        if i > max_instances vertices || i < 0 then
+          raise (Invalid_argument "Invalid number of instances")
+        else
+          i
+    in
     M.bind target parameters;
     Program.LL.use context (Some program);
     Uniform.LL.bind context uniform (Program.LL.uniforms program);
     bind context vertices program;
     match indices with
     |None -> 
-      if start < 0 || start + length > vertices.length then
-        raise (Out_of_bounds "Invalid vertex array bounds")
-      (*else if vertices.instanced then 
-        GL.VAO.draw_instanced mode start length*)
+      if start < 0 || start + length > vertices.length || length < 0 then
+        raise (Invalid_argument "Invalid vertex array bounds")
+      else if vertices.instanced then 
+        GL.VAO.draw_instanced mode start length instances
       else
         GL.VAO.draw mode start length
     |Some ebo ->
-      if start < 0 || start + length > (IndexArray.length ebo) then
-        raise (Out_of_bounds "Invalid index array bounds")
-      (*else if vertices.instanced then begin
+      if start < 0 || start + length > (IndexArray.length ebo) || length < 0 then
+        raise (Invalid_argument "Invalid index array bounds")
+      else if vertices.instanced then begin
         IndexArray.LL.bind context ebo;
-        GL.VAO.draw_elements_instanced mode start length 
-      end*) else begin
+        GL.VAO.draw_elements_instanced mode start length instances
+      end else begin
         IndexArray.LL.bind context ebo;
         GL.VAO.draw_elements mode start length 
       end
   end
-

--- a/src/graphics/vertex/vertexArray.mli
+++ b/src/graphics/vertex/vertexArray.mli
@@ -127,8 +127,10 @@ module Buffer : sig
   type static
   
   type dynamic
-  
+ 
   type ('a, 'b) t 
+
+  type unpacked
   
   val static : (module RenderTarget.T with type t = 'a) 
                 -> 'a -> 'b Source.t -> (static, 'b) t
@@ -136,8 +138,6 @@ module Buffer : sig
   val dynamic : (module RenderTarget.T with type t = 'a) 
                  -> 'a -> 'b Source.t -> (dynamic, 'b) t
  
-  val unpack : ('a, 'b) t -> (unit, 'b) t
-
   val length : (_, _) t -> int
 
   val blit    : (module RenderTarget.T with type t = 'a) ->
@@ -145,29 +145,27 @@ module Buffer : sig
                  ?first:int -> ?length:int ->
                  'b Source.t -> unit
 
+  val unpack : (_, _) t -> unpacked
+
 end
 
 exception Missing_attribute of string
 
 exception Multiple_definition of string
 
-exception Length_mismatch 
+type t
 
-type 'a t
-
-val create : 
-  (module RenderTarget.T with type t = 'a) -> 
-  'a -> ('b, 'c) Buffer.t list -> 'c t
+val create : (module RenderTarget.T with type t = 'a) -> 'a -> Buffer.unpacked list -> t
 
 (* Number of vertices in the array (0 if all the data is instanced) *)
-val length : 'a t -> int
+val length : t -> int
 
-(* Maximal number of drawable instances *)
-val max_instances : 'a t -> int
+(* Maximal number of drawable instances. None if non-instanced *)
+val max_instances : t -> int option
 
 val draw :
   (module RenderTarget.T with type t = 'a) ->
-  vertices   : (_, _) t ->
+  vertices   : t ->
   target     : 'a ->
   ?instances : int ->
   ?indices   : _ IndexArray.t ->

--- a/src/graphics/vertex/vertexArray.mli
+++ b/src/graphics/vertex/vertexArray.mli
@@ -41,6 +41,8 @@ module Vertex : sig
 
     val name : ('a, 'b) s -> string
 
+    val divisor : ('a, 'b) s -> int
+
     val atype : ('a, 'b) s -> 'a AttributeType.s
 
   end
@@ -50,7 +52,7 @@ module Vertex : sig
 
     type s
 
-    val attribute : string -> 'a AttributeType.s -> ('a, s) Attribute.s
+    val attribute : string -> ?divisor:int -> 'a AttributeType.s -> ('a, s) Attribute.s
 
     val seal : unit -> unit
 
@@ -133,7 +135,8 @@ val static : (module RenderTarget.T with type t = 'a)
 val dynamic : (module RenderTarget.T with type t = 'a) 
                -> 'a -> 'b VertexSource.t -> (dynamic, 'b) t
 
-val rebuild : (dynamic, 'b) t -> 'b VertexSource.t -> int -> unit
+val rebuild : (module RenderTarget.T with type t = 'a)
+               -> 'a -> (dynamic, 'b) t -> 'b VertexSource.t -> int -> unit
 
 val length : (_, _) t -> int
 

--- a/tests/vertexarrays.ml
+++ b/tests/vertexarrays.ml
@@ -77,17 +77,18 @@ let program = Program.from_source_list
     ] ()
 
 let test_vao1 () =
-  let vsource = VertexArray.(VertexSource.(
+  let vsource = VertexArray.(Source.(
     empty ~size:4 ()
     << SimpleVertex.create ~position:Vector3f.unit_z ()
     << SimpleVertex.create ~position:Vector3f.unit_y ()
     << SimpleVertex.create ~position:Vector3f.unit_x ()
   )) in
-  let vao = VertexArray.dynamic (module Window) window vsource in
+  let vbo = VertexArray.Buffer.dynamic (module Window) window vsource in
+  let vao = VertexArray.(create (module Window) window [Buffer.unpack vbo]) in
   assert (VertexArray.length vao = 3)
 
 let test_vao2 () =
-  let vsource = VertexArray.(VertexSource.(
+  let vsource = VertexArray.(Source.(
     empty ~size:4 ()
     << SimpleVertex.create ~position:Vector3f.unit_z ()
     << SimpleVertex.create ~position:Vector3f.unit_y ()
@@ -96,12 +97,13 @@ let test_vao2 () =
     << SimpleVertex.create ~position:Vector3f.unit_x ()
     << SimpleVertex.create ~position:Vector3f.unit_x ()
   )) in
-  let vao = VertexArray.dynamic (module Window) window vsource in
+  let vbo = VertexArray.Buffer.dynamic (module Window) window vsource in
+  let vao = VertexArray.(create (module Window) window [Buffer.unpack vbo]) in
   assert (VertexArray.length vao = 6)
 
 let test_vao3 () =
   try
-    let vsource = VertexArray.(VertexSource.(
+    let vsource = VertexArray.(Source.(
       empty ~size:4 ()
       << SimpleVertex.create ~position:Vector3f.unit_z ()
       << SimpleVertex.create ()
@@ -109,49 +111,52 @@ let test_vao3 () =
     ignore vsource;
     assert false
   with
-    |VertexArray.VertexSource.Uninitialized_field _ -> ()
+    |VertexArray.Source.Uninitialized_field _ -> ()
 
 let test_vao4 () =
   try
-    let vsource = VertexArray.(VertexSource.(
+    let vsource = VertexArray.(Source.(
       empty ~size:4 ()
       << SimpleVertex.create ~position:Vector3f.unit_z ()
       << SimpleVertex.create ~position:Vector3f.unit_z ~color:(`RGB Color.RGB.white) ()
     )) in
     ignore vsource
   with
-    |VertexArray.VertexSource.Uninitialized_field _ -> assert false
+    |VertexArray.Source.Uninitialized_field _ -> assert false
 
 let test_vao5 () =
-  let vsource = VertexArray.(VertexSource.(
+  let vsource = VertexArray.(Source.(
     empty ~size:4 ()
     << SimpleVertex.create ~position:Vector3f.unit_z ~uv:Vector2f.({x = 1.; y = 1.}) ~normal:Vector3f.unit_z ~color:(`RGB Color.RGB.white) ()
     << SimpleVertex.create ~position:Vector3f.unit_y ~uv:Vector2f.({x = 1.; y = 1.}) ~normal:Vector3f.unit_z ~color:(`RGB Color.RGB.white) ()
     << SimpleVertex.create ~position:Vector3f.unit_x ~uv:Vector2f.({x = 1.; y = 1.}) ~normal:Vector3f.unit_z ~color:(`RGB Color.RGB.white) ()
     << SimpleVertex.create ~position:Vector3f.unit_x ~uv:Vector2f.({x = 1.; y = 1.}) ~normal:Vector3f.unit_z ~color:(`RGB Color.RGB.white) ()
   )) in
-  let vao = VertexArray.dynamic (module Window) window vsource in
+  let vbo = VertexArray.Buffer.dynamic (module Window) window vsource in
+  let vao = VertexArray.(create (module Window) window [Buffer.unpack vbo]) in
   assert (VertexArray.length vao = 4)
 
 let test_vao6 () =
-  let vsource = VertexArray.(VertexSource.(
+  let vsource = VertexArray.(Source.(
     empty ~size:4 ()
     << SimpleVertex.create ~position:Vector3f.unit_z ()
     << SimpleVertex.create ~position:Vector3f.unit_y ()
     << SimpleVertex.create ~position:Vector3f.unit_x ()
   )) in
-  let vao = VertexArray.dynamic (module Window) window vsource in
+  let vbo = VertexArray.Buffer.dynamic (module Window) window vsource in
+  let vao = VertexArray.(create (module Window) window [Buffer.unpack vbo]) in
   VertexArray.draw (module Window) ~target:window 
                    ~vertices:vao ~program ~parameters ~mode ~uniform ()
 
 let test_vao7 () =
-  let vsource = VertexArray.(VertexSource.(
+  let vsource = VertexArray.(Source.(
     empty ~size:4 ()
     << SimpleVertex.create ~normal:Vector3f.unit_z ()
     << SimpleVertex.create ~normal:Vector3f.unit_y ()
     << SimpleVertex.create ~normal:Vector3f.unit_x ()
   )) in
-  let vao = VertexArray.dynamic (module Window) window vsource in
+  let vbo = VertexArray.Buffer.dynamic (module Window) window vsource in
+  let vao = VertexArray.(create (module Window) window [Buffer.unpack vbo]) in
   try
     VertexArray.draw (module Window) ~target:window ~vertices:vao ~program ~parameters ~mode ~uniform ();
     assert false
@@ -160,46 +165,48 @@ let test_vao7 () =
 
 
 let test_vao8 () =
-  let vsource = VertexArray.(VertexSource.(
+  let vsource = VertexArray.(Source.(
     empty ~size:4 ()
     << SimpleVertex.create ~position:Vector3f.unit_z ~color:(`RGB Color.RGB.white) ()
     << SimpleVertex.create ~position:Vector3f.unit_y ~color:(`RGB Color.RGB.white) ()
     << SimpleVertex.create ~position:Vector3f.unit_x ~color:(`RGB Color.RGB.white) ()
   )) in
-  let vao = VertexArray.dynamic (module Window) window vsource in
+  let vbo = VertexArray.Buffer.dynamic (module Window) window vsource in
+  let vao = VertexArray.(create (module Window) window [Buffer.unpack vbo]) in
   try
     VertexArray.draw (module Window) ~target:window ~vertices:vao ~program ~parameters ~mode ~uniform ();
   with
-    VertexArray.Invalid_attribute _ -> assert false
+    VertexArray.Buffer.Invalid_attribute _ -> assert false
 
 let test_vao9 () = 
-  let vsource = VertexArray.(VertexSource.(
+  let vsource = VertexArray.(Source.(
     empty ~size:4 ()
     << SimpleVertex.create ~normal:Vector3f.unit_z ()
     << SimpleVertex.create ~normal:Vector3f.unit_y ()
     << SimpleVertex.create ~normal:Vector3f.unit_x ()
   )) in
   let vsource = 
-    VertexArray.VertexSource.map vsource 
+    VertexArray.Source.map vsource 
       (fun vtx -> 
         VertexArray.SimpleVertex.create 
           ~position:(VertexArray.Vertex.Attribute.get vtx VertexArray.SimpleVertex.normal)
           ()
       )
   in
-  let vao = VertexArray.dynamic (module Window) window vsource in
+  let vbo = VertexArray.Buffer.dynamic (module Window) window vsource in
+  let vao = VertexArray.(create (module Window) window [Buffer.unpack vbo]) in
   try
     VertexArray.draw (module Window) ~target:window ~vertices:vao ~program ~parameters ~mode ~uniform ();
   with
     VertexArray.Missing_attribute _ -> ()
 
 let test_vao10 () = 
-  let vsource = VertexArray.(VertexSource.(
+  let vsource = VertexArray.(Source.(
     empty ~size:4 ()
     << SimpleVertex.create ~position:Vector3f.unit_z ~normal:Vector3f.unit_y ()
     << SimpleVertex.create ~position:Vector3f.unit_z ~normal:Vector3f.unit_y ~color:(`RGB Color.RGB.black) ()
   )) in
-  VertexArray.VertexSource.iter vsource
+  VertexArray.Source.iter vsource
     (fun vtx ->
       let open VertexArray in
       assert (Vertex.Attribute.get vtx SimpleVertex.position = Vector3f.unit_z);


### PR DESCRIPTION
Added support for instanced rendering as well as multiple vertex buffers per vertex array. 
Contains important and breaking changes to the interface of vertex arrays.

Seems to work properly on Linux, but not everything has been tested thoroughly, and instancing is still to be tested on MacOS.

Smaller changes:
- Added finalisation and reuse of internal IDs
- Fixed a rare case where a vertex array could be unbound before drawing (due to GC + state persistence)
- Fixed unsound state changes in IndexArray.rebuild